### PR TITLE
feat(Droppable): allow granular control over combine feature

### DIFF
--- a/package.json
+++ b/package.json
@@ -80,6 +80,7 @@
     "raf-schd": "^4.0.3",
     "react-redux": "^8.1.1",
     "redux": "^4.2.1",
+    "ts-node": "^10.9.1",
     "use-memo-one": "^1.1.3"
   },
   "devDependencies": {

--- a/src/state/droppable/get-droppable.ts
+++ b/src/state/droppable/get-droppable.ts
@@ -3,6 +3,7 @@ import type {
   Axis,
   DroppableDimension,
   DroppableDescriptor,
+  DraggableDescriptor,
   Scrollable,
   DroppableSubject,
   ScrollSize,
@@ -24,6 +25,7 @@ interface Args {
   descriptor: DroppableDescriptor;
   isEnabled: boolean;
   isCombineEnabled: boolean;
+  isCombineAllowedForItem?: (descriptor: DraggableDescriptor) => boolean;
   isFixedOnPage: boolean;
   direction: 'vertical' | 'horizontal';
   client: BoxModel;
@@ -36,6 +38,7 @@ export default ({
   descriptor,
   isEnabled,
   isCombineEnabled,
+  isCombineAllowedForItem,
   isFixedOnPage,
   direction,
   client,
@@ -87,6 +90,7 @@ export default ({
   const dimension: DroppableDimension = {
     descriptor,
     isCombineEnabled,
+    isCombineAllowedForItem,
     isFixedOnPage,
     axis,
     isEnabled,

--- a/src/state/get-drag-impact/get-combine-impact.ts
+++ b/src/state/get-drag-impact/get-combine-impact.ts
@@ -105,7 +105,11 @@ export default ({
     );
   });
 
-  if (!combineWith) {
+  if (
+    !combineWith ||
+    (destination.isCombineAllowedForItem &&
+      !destination.isCombineAllowedForItem(combineWith.descriptor))
+  ) {
     return null;
   }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -140,6 +140,7 @@ export interface DroppableDimension {
   axis: Axis;
   isEnabled: boolean;
   isCombineEnabled: boolean;
+  isCombineAllowedForItem?: (combineWith: DraggableDescriptor) => boolean;
   // relative to the current viewport
   client: BoxModel;
   // relative to the whole page

--- a/src/view/droppable/connected-droppable.ts
+++ b/src/view/droppable/connected-droppable.ts
@@ -44,6 +44,7 @@ const defaultProps: DefaultProps = {
   direction: 'vertical',
   isDropDisabled: false,
   isCombineEnabled: false,
+  isCombineAllowedForItem: undefined,
   ignoreContainerClipping: false,
   renderClone: null,
   getContainerForClone: getBody,

--- a/src/view/droppable/droppable-types.ts
+++ b/src/view/droppable/droppable-types.ts
@@ -9,6 +9,7 @@ import type {
   ContextId,
   DraggableRubric,
   DroppableMode,
+  DraggableDescriptor,
 } from '../../types';
 import type { DraggableChildrenFn } from '../draggable/draggable-types';
 import { updateViewportMaxScroll } from '../../state/action-creators';
@@ -62,6 +63,9 @@ export interface DefaultProps {
   getContainerForClone: () => HTMLElement;
   ignoreContainerClipping: boolean;
   isCombineEnabled: boolean;
+  isCombineAllowedForItem:
+    | ((combineWith: DraggableDescriptor) => boolean)
+    | undefined;
   isDropDisabled: boolean;
   mode: DroppableMode;
   type: TypeId;

--- a/src/view/droppable/droppable.tsx
+++ b/src/view/droppable/droppable.tsx
@@ -41,6 +41,7 @@ const Droppable: FunctionComponent<Props> = (props) => {
     ignoreContainerClipping,
     isDropDisabled,
     isCombineEnabled,
+    isCombineAllowedForItem,
     // map props
     snapshot,
     useClone,
@@ -86,6 +87,7 @@ const Droppable: FunctionComponent<Props> = (props) => {
     direction,
     isDropDisabled,
     isCombineEnabled,
+    isCombineAllowedForItem,
     ignoreContainerClipping,
     getDroppableRef,
   });

--- a/src/view/use-droppable-publisher/get-dimension.ts
+++ b/src/view/use-droppable-publisher/get-dimension.ts
@@ -6,6 +6,7 @@ import type { Env } from './get-env';
 import type {
   DroppableDimension,
   DroppableDescriptor,
+  DraggableDescriptor,
   Direction,
   ScrollSize,
 } from '../../types';
@@ -78,6 +79,7 @@ interface Args {
   direction: Direction;
   isDropDisabled: boolean;
   isCombineEnabled: boolean;
+  isCombineAllowedForItem?: (combineWith: DraggableDescriptor) => boolean;
   shouldClipSubject: boolean;
 }
 
@@ -89,6 +91,7 @@ export default ({
   direction,
   isDropDisabled,
   isCombineEnabled,
+  isCombineAllowedForItem,
   shouldClipSubject,
 }: Args): DroppableDimension => {
   const closestScrollable: Element | null = env.closestScrollable;
@@ -119,6 +122,7 @@ export default ({
     descriptor,
     isEnabled: !isDropDisabled,
     isCombineEnabled,
+    isCombineAllowedForItem,
     isFixedOnPage: env.isFixedOnPage,
     direction,
     client,

--- a/src/view/use-droppable-publisher/use-droppable-publisher.ts
+++ b/src/view/use-droppable-publisher/use-droppable-publisher.ts
@@ -20,6 +20,7 @@ import type {
   TypeId,
   DroppableDimension,
   DroppableDescriptor,
+  DraggableDescriptor,
   Direction,
   ScrollOptions,
   DroppableMode,
@@ -41,6 +42,7 @@ interface Props {
   direction: Direction;
   isDropDisabled: boolean;
   isCombineEnabled: boolean;
+  isCombineAllowedForItem?: (combineWith: DraggableDescriptor) => boolean;
   ignoreContainerClipping: boolean;
   getDroppableRef: () => HTMLElement | null;
 }
@@ -150,6 +152,7 @@ export default function useDroppablePublisher(args: Props) {
         direction: previous.direction,
         isDropDisabled: previous.isDropDisabled,
         isCombineEnabled: previous.isCombineEnabled,
+        isCombineAllowedForItem: previous.isCombineAllowedForItem,
         shouldClipSubject: !previous.ignoreContainerClipping,
       });
 

--- a/test/unit/view/connected-droppable/util/get-own-props.ts
+++ b/test/unit/view/connected-droppable/util/get-own-props.ts
@@ -7,6 +7,7 @@ export default (dimension: DroppableDimension): InternalOwnProps => ({
   type: dimension.descriptor.type,
   isDropDisabled: false,
   isCombineEnabled: true,
+  isCombineAllowedForItem: undefined,
   direction: dimension.axis.direction,
   ignoreContainerClipping: false,
   children: () => null,

--- a/test/unit/view/droppable/util/get-props.ts
+++ b/test/unit/view/droppable/util/get-props.ts
@@ -14,6 +14,7 @@ export const homeOwnProps: Required<DroppableProps> = {
   mode: preset.home.descriptor.mode,
   isDropDisabled: false,
   isCombineEnabled: false,
+  isCombineAllowedForItem: () => true,
   direction: preset.home.axis.direction,
   ignoreContainerClipping: false,
   children: () => null,

--- a/test/unit/view/use-droppable-publisher/util/shared.tsx
+++ b/test/unit/view/use-droppable-publisher/util/shared.tsx
@@ -11,6 +11,7 @@ import type {
   ScrollOptions,
   DroppableId,
   DroppableDescriptor,
+  DraggableDescriptor,
   TypeId,
 } from '../../../../../src/types';
 import createRef from '../../../../util/create-ref';
@@ -111,6 +112,7 @@ interface ScrollableItemProps {
   isScrollable?: boolean;
   isDropDisabled?: boolean;
   isCombineEnabled?: boolean;
+  isCombineAllowedForItem?: (combineWith: DraggableDescriptor) => boolean;
   droppableId?: DroppableId;
 }
 
@@ -129,6 +131,7 @@ export function ScrollableItem(props: ScrollableItemProps) {
     ignoreContainerClipping: false,
     getDroppableRef: droppableRef.getRef,
     isCombineEnabled: props.isCombineEnabled || false,
+    isCombineAllowedForItem: props.isCombineAllowedForItem || undefined,
   });
 
   return (


### PR DESCRIPTION
introduce a isCombineAllowedForItem prop to Droppagle component to filter draggable items that can combine