### PR TITLE
refactor: remove optional chaining from the codebase

### DIFF
--- a/src/view/window/get-window-from-el.ts
+++ b/src/view/window/get-window-from-el.ts
@@ -1,2 +1,7 @@
-export default (el?: Element | null): typeof window =>
-  el?.ownerDocument?.defaultView || window;
+export default (el?: Element | null): typeof window => {
+  if (el && el.ownerDocument && el.ownerDocument.defaultView) {
+    return el.ownerDocument.defaultView;
+  }
+
+  return window;
+};


### PR DESCRIPTION
We are removing the optional chaining because one of our users is having issues with an old babel version that doesn't work with optional chaining.

fix #720