### PR TITLE
docs(storybook): fix documentation link

### DIFF
--- a/stories/Welcome.mdx
+++ b/stories/Welcome.mdx
@@ -11,5 +11,5 @@ See the [first example](?path=/story/examples-single-vertical-list--basic).
 ## Links
 
 * [GitHub repo](https://github.com/hello-pangea/dnd)
-* [Documentation](https://github.com/hello-pangea/dnd#documentation-=)
+* [Documentation](https://github.com/hello-pangea/dnd#documentation-)
 * [NPM](https://www.npmjs.com/package/@hello-pangea/dnd)


### PR DESCRIPTION
The current link has an = that was removed in this commit