### PR TITLE
fix: dnd in popout window through react portal

### DIFF
--- a/src/view/drag-drop-context/app.tsx
+++ b/src/view/drag-drop-context/app.tsx
@@ -70,6 +70,7 @@ export interface Props extends Responders {
   // options to exert more control over autoScroll
   // eslint-disable-next-line react/no-unused-prop-types
   autoScrollerOptions?: PartialAutoScrollerOptions;
+  targetWindow?: Window;
 }
 
 const createResponders = (props: Props): Responders => ({
@@ -134,7 +135,9 @@ export default function App(props: Props) {
     contextId,
     text: dragHandleUsageInstructions,
   });
-  const styleMarshal: StyleMarshal = useStyleMarshal(contextId, nonce);
+  // Ensure document is defined before using it as a fallback for SSR
+  const targetDoc = props.targetWindow?.document || (typeof document !== 'undefined' ? document : undefined);
+  const styleMarshal: StyleMarshal = useStyleMarshal(contextId, nonce, targetDoc);
 
   const lazyDispatch: (a: Action) => void = useCallback(
     (action: Action): void => {

--- a/src/view/drag-drop-context/drag-drop-context.tsx
+++ b/src/view/drag-drop-context/drag-drop-context.tsx
@@ -22,6 +22,7 @@ export interface DragDropContextProps extends Responders {
    * Customize auto scroller
    */
   autoScrollerOptions?: PartialAutoScrollerOptions;
+  targetWindow?: Window;
 }
 
 export default function DragDropContext(props: DragDropContextProps) {
@@ -47,6 +48,7 @@ export default function DragDropContext(props: DragDropContextProps) {
           onDragUpdate={props.onDragUpdate}
           onDragEnd={props.onDragEnd}
           autoScrollerOptions={props.autoScrollerOptions}
+          targetWindow={props.targetWindow}
         >
           {props.children}
         </App>

--- a/src/view/draggable/use-validation.ts
+++ b/src/view/draggable/use-validation.ts
@@ -43,8 +43,13 @@ export function useValidation(
     // Only running check when enabled.
     // When not enabled there is no drag handle props
     if (props.isEnabled) {
+      const draggableElement = getRef();
+      // If the draggable element exists, use its ownerDocument.
+      // Otherwise, (e.g. SSR or ref not yet set) pass undefined to findDragHandle.
+      const docToSearchIn = draggableElement ? draggableElement.ownerDocument : undefined;
+
       invariant(
-        findDragHandle(contextId, id),
+        findDragHandle(contextId, id, docToSearchIn),
         `${prefix(id)} Unable to find drag handle`,
       );
     }

--- a/src/view/get-elements/find-drag-handle.ts
+++ b/src/view/get-elements/find-drag-handle.ts
@@ -7,13 +7,16 @@ import isHtmlElement from '../is-type-of-element/is-html-element';
 export default function findDragHandle(
   contextId: ContextId,
   draggableId: DraggableId,
+  doc?: Document,
 ): HTMLElement | null {
-  // cannot create a selector with the draggable id as it might not be a valid attribute selector
+  if (!doc) {
+    return null;
+  }
   const selector = `[${dragHandleAttr.contextId}="${contextId}"]`;
-  const possible = querySelectorAll(document, selector);
+  const possible = querySelectorAll(doc, selector);
 
   if (!possible.length) {
-    warning(`Unable to find any drag handles in the context "${contextId}"`);
+    warning(`Unable to find any drag handles with contextId "${contextId}" in the provided document`);
     return null;
   }
 
@@ -23,7 +26,7 @@ export default function findDragHandle(
 
   if (!handle) {
     warning(
-      `Unable to find drag handle with id "${draggableId}" as no handle with a matching id was found`,
+      `Unable to find drag handle with draggableId "${draggableId}" (contextId "${contextId}") in the provided document`,
     );
     return null;
   }

--- a/src/view/get-elements/find-draggable.ts
+++ b/src/view/get-elements/find-draggable.ts
@@ -7,10 +7,14 @@ import isHtmlElement from '../is-type-of-element/is-html-element';
 export default function findDraggable(
   contextId: ContextId,
   draggableId: DraggableId,
+  doc?: Document
 ): HTMLElement | null {
+  if (!doc) { // If no document context, cannot find element
+    return null;
+  }
   // cannot create a selector with the draggable id as it might not be a valid attribute selector
   const selector = `[${attributes.draggable.contextId}="${contextId}"]`;
-  const possible = querySelectorAll(document, selector);
+  const possible = querySelectorAll(doc, selector);
 
   const draggable = possible.find((el): boolean => {
     return el.getAttribute(attributes.draggable.id) === draggableId;

--- a/src/view/use-style-marshal/use-style-marshal.ts
+++ b/src/view/use-style-marshal/use-style-marshal.ts
@@ -9,14 +9,18 @@ import type { Styles } from './get-styles';
 import { prefix } from '../data-attributes';
 import useLayoutEffect from '../use-isomorphic-layout-effect';
 
-const getHead = (): HTMLHeadElement => {
-  const head: HTMLHeadElement | null = document.querySelector('head');
-  invariant(head, 'Cannot find the head to append a style to');
+const getHead = (targetDoc?: Document): HTMLHeadElement | null => {
+  if (!targetDoc) return null;
+  const head: HTMLHeadElement | null = targetDoc.querySelector('head');
+  if (targetDoc && !head) {
+    invariant(false, 'Cannot find the head to append a style to in the provided document');
+  }
   return head;
 };
 
-const createStyleEl = (nonce?: string): HTMLStyleElement => {
-  const el: HTMLStyleElement = document.createElement('style');
+const createStyleEl = (targetDoc?: Document, nonce?: string): HTMLStyleElement | null => {
+  if (!targetDoc) return null;
+  const el: HTMLStyleElement = targetDoc.createElement('style');
   if (nonce) {
     el.setAttribute('nonce', nonce);
   }
@@ -24,60 +28,84 @@ const createStyleEl = (nonce?: string): HTMLStyleElement => {
   return el;
 };
 
-export default function useStyleMarshal(contextId: ContextId, nonce?: string) {
+export default function useStyleMarshal(
+  contextId: ContextId,
+  nonce?: string,
+  targetDocFromApp?: Document
+): StyleMarshal {
+  // Determine the effective document to use:
+  // 1. Use the one passed from App (targetDocFromApp).
+  // 2. If not passed, fallback to global document if it exists (for direct test usage or other contexts).
+  // 3. If global document also doesn't exist (SSR context where app.tsx also found it undefined), it remains undefined.
+  const effectiveTargetDoc = targetDocFromApp || (typeof document !== 'undefined' ? document : undefined);
+
   const styles: Styles = useMemo(() => getStyles(contextId), [contextId]);
   const alwaysRef = useRef<HTMLStyleElement | null>(null);
   const dynamicRef = useRef<HTMLStyleElement | null>(null);
 
-  // eslint-disable-next-line react-hooks/exhaustive-deps
   const setDynamicStyle = useCallback(
-    // Using memoizeOne to prevent frequent updates to textContext
     memoizeOne((proposed: string) => {
       const el: HTMLStyleElement | null = dynamicRef.current;
-      invariant(el, 'Cannot set dynamic style element if it is not set');
-      el.textContent = proposed;
+      if (el) {
+        el.textContent = proposed;
+      }
     }),
     [],
   );
 
   const setAlwaysStyle = useCallback((proposed: string) => {
     const el: HTMLStyleElement | null = alwaysRef.current;
-    invariant(el, 'Cannot set dynamic style element if it is not set');
-    el.textContent = proposed;
+    if (el) {
+      el.textContent = proposed;
+    }
   }, []);
 
-  // using layout effect as programatic dragging might start straight away (such as for cypress)
   useLayoutEffect(() => {
+    if (!effectiveTargetDoc) { // Use the determined effectiveTargetDoc
+      return;
+    }
+
     invariant(
       !alwaysRef.current && !dynamicRef.current,
       'style elements already mounted',
     );
 
-    const always: HTMLStyleElement = createStyleEl(nonce);
-    const dynamic: HTMLStyleElement = createStyleEl(nonce);
+    const always: HTMLStyleElement | null = createStyleEl(effectiveTargetDoc, nonce);
+    const dynamic: HTMLStyleElement | null = createStyleEl(effectiveTargetDoc, nonce);
+    
+    if (!always || !dynamic) {
+        return;
+    }
 
-    // store their refs
     alwaysRef.current = always;
     dynamicRef.current = dynamic;
 
-    // for easy identification
     always.setAttribute(`${prefix}-always`, contextId);
     dynamic.setAttribute(`${prefix}-dynamic`, contextId);
 
-    // add style tags to head
-    getHead().appendChild(always);
-    getHead().appendChild(dynamic);
+    const head = getHead(effectiveTargetDoc);
+    if (head) {
+        head.appendChild(always);
+        head.appendChild(dynamic);
+    }
 
-    // set initial style
     setAlwaysStyle(styles.always);
     setDynamicStyle(styles.resting);
 
     return () => {
+      if (!effectiveTargetDoc) { // Use the determined effectiveTargetDoc
+        return;
+      }
+
       const remove = (ref: MutableRefObject<HTMLStyleElement | null>) => {
         const current: HTMLStyleElement | null = ref.current;
-        invariant(current, 'Cannot unmount ref as it is not set');
-        getHead().removeChild(current);
-        ref.current = null;
+        if (current) {
+            const head = getHead(effectiveTargetDoc); // Use effectiveTargetDoc
+            if (head && head.contains(current)) { 
+                 head.removeChild(current);
+            }
+            ref.current = null;
+        }
       };
 
       remove(alwaysRef);
@@ -90,6 +118,7 @@ export default function useStyleMarshal(contextId: ContextId, nonce?: string) {
     styles.always,
     styles.resting,
     contextId,
+    effectiveTargetDoc, // Depend on effectiveTargetDoc
   ]);
 
   const dragging = useCallback(
@@ -107,12 +136,12 @@ export default function useStyleMarshal(contextId: ContextId, nonce?: string) {
     [setDynamicStyle, styles.dropAnimating, styles.userCancel],
   );
   const resting = useCallback(() => {
-    // Can be called defensively
-    if (!dynamicRef.current) {
+    // Use effectiveTargetDoc for condition consistency
+    if (!dynamicRef.current && !effectiveTargetDoc) { 
       return;
     }
     setDynamicStyle(styles.resting);
-  }, [setDynamicStyle, styles.resting]);
+  }, [setDynamicStyle, styles.resting, effectiveTargetDoc]); // Depend on effectiveTargetDoc
 
   const marshal: StyleMarshal = useMemo(
     () => ({

--- a/stories/examples/100-popout-dnd.stories.tsx
+++ b/stories/examples/100-popout-dnd.stories.tsx
@@ -1,0 +1,335 @@
+import React, { useState, useEffect, useCallback, useRef } from 'react';
+import ReactDOM from 'react-dom';
+import {
+  DragDropContext,
+  Droppable,
+  Draggable,
+  OnDragEndResponder,
+  DraggableProvided,
+  DroppableProvided,
+  DropResult,
+  SensorAPI,
+  TryGetLockOptions,
+  FluidDragActions,
+} from '@hello-pangea/dnd';
+
+// Helper to create some items
+const getItems = (count: number, offset = 0): Item[] =>
+  Array.from({ length: count }, (v, k) => k + offset).map(k => ({
+    id: `item-${k}-${Date.now()}`, // Unique IDs for re-renders
+    content: `Item ${k}`,
+  }));
+
+// Helper function to reorder a list
+const reorder = (list: Item[], startIndex: number, endIndex: number): Item[] => {
+  const result = Array.from(list);
+  const [removed] = result.splice(startIndex, 1);
+  result.splice(endIndex, 0, removed);
+  return result;
+};
+
+interface Item {
+  id: string;
+  content: string;
+}
+
+// Define an augmented options type for story, until library types are patched
+interface PatchedTryGetLockOptions extends TryGetLockOptions {
+  targetDocument?: Document;
+}
+
+interface DndListComponentProps {
+  items: Item[];
+  onItemsChange: (items: Item[]) => void;
+  windowContext?: Window;
+}
+
+// Define a custom sensor that uses windowContext
+const useCustomSensorWithWindowContext = (api: SensorAPI, windowCtx?: Window) => {
+  const dragActionsRef = useRef<FluidDragActions | null>(null);
+  const winRef = useRef(windowCtx || window.self);
+
+  useEffect(() => {
+    winRef.current = windowCtx || window.self;
+  }, [windowCtx]);
+
+  const handleMouseMove = useCallback((event: MouseEvent) => {
+    if (dragActionsRef.current) {
+      dragActionsRef.current.move({ x: event.clientX, y: event.clientY });
+    }
+  }, []);
+
+  const handleMouseUp = useCallback(
+    (event: MouseEvent) => {
+      winRef.current.document.removeEventListener('mousemove', handleMouseMove as EventListener);
+      winRef.current.document.removeEventListener('mouseup', handleMouseUp as EventListener);
+
+      if (dragActionsRef.current) {
+        dragActionsRef.current.drop();
+        dragActionsRef.current = null;
+      }
+    },
+    [handleMouseMove] 
+  );
+
+  const startDrag = useCallback(
+    (event: MouseEvent) => {
+      if (dragActionsRef.current) {
+        return;
+      }
+
+      const target = event.target as HTMLElement;
+      let draggableId: string | null = null;
+      let currentElement: HTMLElement | null = target;
+      while(currentElement && !draggableId) {
+        draggableId = currentElement.getAttribute('data-rfd-draggable-id');
+        if (!draggableId) {
+            draggableId = currentElement.getAttribute('data-rfd-drag-handle-draggable-id');
+        }
+        currentElement = currentElement.parentElement;
+      }
+      if(!draggableId && target.hasAttribute('data-rfd-draggable-id')) {
+        draggableId = target.getAttribute('data-rfd-draggable-id');
+      }
+
+      if (!draggableId) return;
+
+      const docForDnd = winRef.current.document;
+
+      const preDrag = api.tryGetLock(draggableId, undefined, {
+        sourceEvent: event,
+        targetDocument: docForDnd,
+      } as PatchedTryGetLockOptions);
+
+      if (!preDrag) {
+        return;
+      }
+      
+      event.preventDefault();
+
+      dragActionsRef.current = preDrag.fluidLift({ x: event.clientX, y: event.clientY });
+      winRef.current.document.addEventListener('mousemove', handleMouseMove as EventListener);
+      winRef.current.document.addEventListener('mouseup', handleMouseUp as EventListener);
+    },
+    [api, handleMouseMove, handleMouseUp]
+  );
+
+  useEffect(() => {
+    const currentWin = winRef.current;
+    currentWin.document.addEventListener('mousedown', startDrag as EventListener);
+
+    return () => {
+      currentWin.document.removeEventListener('mousedown', startDrag as EventListener);
+      currentWin.document.removeEventListener('mousemove', handleMouseMove as EventListener);
+      currentWin.document.removeEventListener('mouseup', handleMouseUp as EventListener);
+      
+      if (dragActionsRef.current) {
+        if (typeof dragActionsRef.current.cancel === 'function') {
+            dragActionsRef.current.cancel();
+        }
+        dragActionsRef.current = null;
+      }
+    };
+  }, [startDrag, handleMouseMove, handleMouseUp]);
+};
+
+const DndListComponent: React.FC<DndListComponentProps> = ({
+  items,
+  onItemsChange,
+  windowContext, // Receive windowContext
+}) => {
+  const onDragEnd: OnDragEndResponder = (result: DropResult) => {
+    if (!result.destination) {
+      // If drag was cancelled or dropped outside, activeDrag should already be null
+      // or handled by the sensor's mouseup.
+      return;
+    }
+    const newItems = reorder(
+      items,
+      result.source.index,
+      result.destination.index
+    );
+    onItemsChange(newItems);
+  };
+  
+  // Memoize the sensor array to prevent re-creation on every render if not necessary
+  const sensors = React.useMemo(() => {
+    // This function will be called by DragDropContext to get the SensorAPI
+    return [(api: SensorAPI) => useCustomSensorWithWindowContext(api, windowContext)];
+  }, [windowContext]);
+
+  return (
+    // Pass the custom sensor to DragDropContext
+    <DragDropContext onDragEnd={onDragEnd} sensors={sensors}  targetWindow={windowContext} >
+      <Droppable droppableId="droppable-list-popout-story">
+        {(provided: DroppableProvided) => (
+          // Add data-rfd-draggable-id to the droppable div for the sensor to find (if needed, or adjust sensor logic)
+          <div
+            {...provided.droppableProps}
+            ref={provided.innerRef}
+            style={{ padding: 8, width: 250, background: '#ADD8E6', border: '1px solid blue', minHeight: '100px' }}
+          >
+            {items.map((item, index) => (
+              <Draggable key={item.id} draggableId={item.id} index={index}>
+                {(providedDraggable: DraggableProvided, snapshot) => (
+                  // Ensure this div has the necessary attributes for the sensor to pick up draggableId
+                  // The library itself adds data-rfd-draggable-id to this element via providedDraggable.draggableProps
+                  <div
+                    ref={providedDraggable.innerRef}
+                    {...providedDraggable.draggableProps} // This applies data-rfd-draggable-id and context-id
+                    {...providedDraggable.dragHandleProps} // This applies data-rfd-drag-handle-draggable-id and context-id
+                    style={{
+                      userSelect: 'none',
+                      padding: '8px 16px',
+                      margin: '0 0 8px 0',
+                      backgroundColor: snapshot.isDragging ? '#4CAF50' : '#2196F3',
+                      color: 'white',
+                      border: '1px solid #1976D2',
+                      ...providedDraggable.draggableProps.style,
+                    }}
+                  >
+                    {item.content}
+                  </div>
+                )}
+              </Draggable>
+            ))}
+            {provided.placeholder}
+          </div>
+        )}
+      </Droppable>
+    </DragDropContext>
+  );
+};
+
+// New component for the controls (button)
+interface PopoutControlsProps {
+  onTogglePopout: () => void;
+  isPopoutOpen: boolean;
+  popoutWindow?: Window | null;
+}
+
+const PopoutControls: React.FC<PopoutControlsProps> = ({ onTogglePopout, isPopoutOpen, popoutWindow }) => {
+  // If in popout, ensure button clicks are handled by the main window's logic
+  // This simple example just calls onTogglePopout directly.
+  // For more complex interactions, you might need window.opener.postMessage or similar.
+  const handleClick = () => {
+    onTogglePopout();
+  };
+
+  return (
+    <button 
+      onClick={handleClick}
+      style={{ padding: '10px 15px', fontSize: '16px', cursor: 'pointer', marginBottom: '20px' }}
+    >
+      {isPopoutOpen ? 'Move to Main Window' : 'Move to Popout Window'}
+    </button>
+  );
+};
+
+const PopoutDndStoryComponent = () => {
+  const [items, setItems] = useState<Item[]>(() => getItems(3));
+  const [popoutTarget, setPopoutTarget] = useState<HTMLDivElement | null>(null);
+  const popoutWindowRef = useRef<Window | null>(null);
+  const [isPopoutOpen, setIsPopoutOpen] = useState(false);
+
+  // Encapsulate popout logic into a single toggle function for the controls
+  const handleTogglePopout = useCallback(() => {
+    if (isPopoutOpen) {
+      // Closing popout
+      if (popoutWindowRef.current && !popoutWindowRef.current.closed) {
+        popoutWindowRef.current.close(); // This will trigger beforeunload
+      } else {
+        // If window already closed by user, just update state
+        setIsPopoutOpen(false);
+        setPopoutTarget(null);
+        popoutWindowRef.current = null;
+      }
+    } else {
+      // Opening popout
+      if (popoutWindowRef.current && !popoutWindowRef.current.closed) {
+          popoutWindowRef.current.focus();
+          return;
+      }
+      const newWindow = window.open('', 'PopoutDndWindowStory', 'width=600,height=400,left=200,top=200');
+      if (newWindow) {
+        popoutWindowRef.current = newWindow;
+        newWindow.document.title = 'D&D Popout Story';
+        const targetDiv = newWindow.document.createElement('div');
+        targetDiv.id = 'popout-dnd-root-story';
+        newWindow.document.body.style.margin = '0';
+        newWindow.document.body.style.padding = '10px';
+        newWindow.document.body.style.backgroundColor = '#f0f0f0';
+        newWindow.document.body.appendChild(targetDiv);
+
+        const styleSheets = Array.from(window.document.styleSheets);
+        styleSheets.forEach(sheet => {
+          try {
+            if (sheet.cssRules) {
+              const newStyleEl = newWindow.document.createElement('style');
+              Array.from(sheet.cssRules).forEach(rule => {
+                newStyleEl.appendChild(newWindow.document.createTextNode(rule.cssText));
+              });
+              newWindow.document.head.appendChild(newStyleEl);
+            } else if (sheet.href) {
+              const newLinkEl = newWindow.document.createElement('link');
+              newLinkEl.rel = 'stylesheet';
+              newLinkEl.href = sheet.href;
+              newWindow.document.head.appendChild(newLinkEl);
+            }
+          } catch (e) {
+            console.warn('Could not copy stylesheet to popout:', e);
+          }
+        });
+        
+        setPopoutTarget(targetDiv);
+        setIsPopoutOpen(true);
+
+        newWindow.addEventListener('beforeunload', () => {
+          setIsPopoutOpen(false);
+          setPopoutTarget(null);
+          popoutWindowRef.current = null;
+        });
+      }
+    }
+  // Ensure dependencies are correct, especially for `isPopoutOpen`
+  }, [isPopoutOpen]);
+
+  useEffect(() => {
+    const currentPopoutWindow = popoutWindowRef.current;
+    return () => {
+      if (currentPopoutWindow && !currentPopoutWindow.closed) {
+        currentPopoutWindow.close();
+      }
+    };
+  }, []);
+
+  // Content to be displayed either in main window or popout
+  const contentToDisplay = (
+    <div style={{border: '1px solid green', padding: '10px'}}>
+      <PopoutControls 
+        onTogglePopout={handleTogglePopout} 
+        isPopoutOpen={isPopoutOpen} 
+        popoutWindow={popoutWindowRef.current} 
+      />
+      <DndListComponent
+        items={items}
+        onItemsChange={setItems}
+        windowContext={isPopoutOpen && popoutWindowRef.current ? popoutWindowRef.current : window}
+      />
+    </div>
+  );
+
+  return (
+    <div style={{ fontFamily: 'Arial, sans-serif', padding: '20px' }}>
+      {!isPopoutOpen && contentToDisplay} 
+      {isPopoutOpen && popoutTarget && ReactDOM.createPortal(contentToDisplay, popoutTarget)}
+    </div>
+  );
+};
+
+export const ListInPopupWindow = PopoutDndStoryComponent;
+
+export default {
+  title: 'Examples/List in Popup Window (React Portal)',
+  component: PopoutDndStoryComponent,
+}; 


### PR DESCRIPTION
This fixes https://github.com/hello-pangea/dnd/issues/442

I have attached a codesandbox with version "@hello-pangea/dnd": "18.0.1" :
1. this example shows when popout button is clicked and DnD list moves to new window created through portal, it breaks and drag and drop doesn't work. refer to console log for errors
https://codesandbox.io/p/sandbox/vibrant-https-wfc2lm

I have also attached a codesandbox with version from my fork "@parassantra/dnd-popout-fix": "18.0.1-popout-fix.0" 
which has patch from current PR:

1. Here we can clearly see when popout button is clicked and DnD list moves to new window created through portal, it works fine and no console errors are there.
https://codesandbox.io/p/sandbox/qm4rtn?file=%2Fpackage.json%3A12%2C5-12%2C57
